### PR TITLE
Better handle urls provided by users. https://drupal.org/node/1874034

### DIFF
--- a/Drupal Create/DGAddSiteViewController.m
+++ b/Drupal Create/DGAddSiteViewController.m
@@ -126,20 +126,12 @@
 
 - (NSString*) getURL {
   NSString *url = [siteUrl text];
-  NSArray *periods = [url componentsSeparatedByString:@"."];
-  NSUInteger periodCount = [periods count] - 1;
-  NSRange rangeOfURL = [url rangeOfString:@"http://"];
-  if (rangeOfURL.location == NSNotFound) {
-    if (periodCount == 1) {
-      url = [NSString stringWithFormat:@"%@%@", @"http://www.", url];
-    } else {
-      url = [NSString stringWithFormat:@"%@%@", @"http://", url];
-    }
-  } else {
-    if (periodCount == 1) {
-      url = [url stringByReplacingOccurrencesOfString:@"http://" withString:@""];
-      url = [NSString stringWithFormat:@"%@%@", @"http://www.", url];
-    }
+  NSURL *myUrl = [[NSURL alloc] initWithString: url];
+  if (!myUrl.scheme) {
+    url = [NSString stringWithFormat:@"%@%@", @"http://", url];
+  }
+  else {
+      url = [myUrl absoluteString];
   }
   return url;
 }


### PR DESCRIPTION
Two faulty assumptions exist:
1) that the supplied url should be prefixed with www if it's doesn't contain more than one period
2) that the schema for requests should be http

Likely NSUrl should be used directly instead of passing the string back in getUrl but this is a first step.

This is also reported as a MASt bug https://drupal.org/node/1874034 and may be related to some Drupal Gardens App store feedback.
